### PR TITLE
Avoid endless resource collection in some cases

### DIFF
--- a/COCBot/functions/Village/Collect.au3
+++ b/COCBot/functions/Village/Collect.au3
@@ -67,6 +67,9 @@ Func Collect()
 				If _Sleep($iDelayCollect1) Then Return
 			EndIf
 			ClickP($aAway, 1, 0, "#0329") ;Click Away
+			If $i >= 20 Then
+			    ExitLoop
+			EndIf
 		ElseIf $i >= 20 Then
 			ExitLoop
 		EndIf


### PR DESCRIPTION
Due to gold mine and elexir collector misdetection (observed in lower TH
levels at least), MyBot happens to endlessly spin in the resource collecting
loop. This patch makes sure to avoid this specific case.